### PR TITLE
Dedupe results; can exclude file paths too

### DIFF
--- a/codesearch_cli.py
+++ b/codesearch_cli.py
@@ -13,11 +13,21 @@ import json
 import requests
 import sys
 import time
+import collections
 
+# result lines have HTML-escaped entities, so prepare an unescaper
+if (sys.version_info > (3, 0)):
+    import html.parser as HTMLParser
+else:
+    import HTMLParser
+unescape = HTMLParser.HTMLParser().unescape
 
 WS_URL = "wss://codesearch.debian.net/instantws"
 rate_limit = 1.0/20  # Rate-limit queries per second
 PATHCOLOR = 33
+DUPE_PATHCOLOR = 36
+
+dedupe_results = []
 
 
 def say(quiet, msg):
@@ -36,6 +46,32 @@ def fetch_json(path):
 
     if r.reason != 'Bad Gateway':
         say(False, "Fetch failure: %s" % r.reason)
+        
+        
+def is_excluded(chunk, exclusions):
+    if exclusions and 'path' in chunk:
+        for exclude in exclusions:
+            if exclude in chunk['path']:
+                return True
+
+
+def get_result_body(chunk, print_linenum, nocolor):
+    body = ""
+    for item in ('ctxp2', 'ctxp1', 'context', 'ctxn1', 'ctxn2'):
+        line = chunk[item]
+        line = line.encode('utf-8')
+        line = unescape(line)
+        if print_linenum:
+            if item == 'context':
+                body += "%7d %s\n" % (chunk['line'], line)
+
+            else:
+                body += "        %s\n" % line
+
+        else:
+            body += "%s\n" % line
+
+    return body[:-1] # trim trailing line
 
 
 def print_results(chunk, print_linenum, print_only_filenames, nocolor):
@@ -51,17 +87,36 @@ def print_results(chunk, print_linenum, print_only_filenames, nocolor):
     if print_only_filenames:
         return
 
-    for item in ('ctxp2', 'ctxp1', 'context', 'ctxn1', 'ctxn2'):
-        line = chunk[item]
-        line = line.encode('utf-8')
-        if print_linenum:
-            if item == 'context':
-                print("%7d %s" % (chunk['line'], line))
-            else:
-                print("        %s" % line)
+    print(get_result_body(chunk, print_linenum, nocolor))
 
+
+def print_dedupe(print_linenum, print_only_filenames, nocolor):
+    """amalgamate duplicate results and print summary
+    """
+
+    bodies = collections.defaultdict(list)
+    for chunk in dedupe_results:
+        body = get_result_body(chunk, print_linenum, nocolor)
+        bodies[body].append(chunk)
+
+    for body, chunks in bodies.items():
+        print_results(chunks[0], print_linenum, print_only_filenames, nocolor)
+
+        first_path = chunks[0]['path']
+        for chunk in chunks[1:]:
+            pathline = "also: %s" % chunk['path']
+            if nocolor:
+                print(pathline)
+
+            else:
+                for common_suffix in range(1, len(pathline)):
+                    if pathline[-common_suffix:] != first_path[-common_suffix:]:
+                        break
+
+                print("\033[%dm%s\033[%dm%s\033[0m" % (PATHCOLOR, pathline[:-common_suffix+1],
+                    DUPE_PATHCOLOR, pathline[-common_suffix+1:]))
         else:
-            print(line)
+            print("")
 
 
 def run_websocket_query(args):
@@ -83,7 +138,10 @@ def run_websocket_query(args):
         except Exception as e:
             say(False, "Unable to parse JSON document %s" % e)
             sys.exit(1)
-
+            
+        if is_excluded(chunk, args.exclude):
+            continue
+           
         if u'Type' in chunk and chunk[u'Type'] == u'progress':
             # Progress update received
             if chunk[u'FilesTotal'] == chunk[u'FilesProcessed']:
@@ -92,7 +150,12 @@ def run_websocket_query(args):
                 return chunk, printed_chunks
 
         elif 'package' in chunk:
-            print_results(chunk, args.linenumber, args.print_filenames, args.nocolor)
+            if args.dedupe:
+                dedupe_results.append(chunk)
+
+            else:
+                print_results(chunk, args.linenumber, args.print_filenames, args.nocolor)
+
             printed_chunks.add((chunk['path'], chunk['line']))
 
 
@@ -107,6 +170,10 @@ def parse_args():
                     help="Do not colorize output")
     ap.add_argument('-n', '--print-filenames', action='store_true',
                     help='Print only matching filenames, no contents')
+    ap.add_argument('-d', '--dedupe', action='store_true',
+                    help='amalgamate results for the same file in different packages')
+    ap.add_argument('-x', '--exclude', action='append',
+                    help='list of path fragments to exclude from results')
     args = ap.parse_args()
     if not sys.stdout.isatty():
         args.nocolor = True
@@ -124,13 +191,19 @@ def fetch_json_pages(query_id, printed_chunks, args):
 
         printed = False
         for chunk in page:
+            if is_excluded(chunk, args.exclude):
+                continue
+            
             if (chunk['path'], chunk['line']) not in printed_chunks:
-                print_results(chunk, args.linenumber, args.print_filenames, args.nocolor)
+                if args.dedupe:
+                    dedupe_results.append(chunk)
+                else:
+                    print_results(chunk, args.linenumber, args.print_filenames, args.nocolor)
                 printed = True
 
-        if sys.stdout.isatty():
+        if not args.dedupe and sys.stdout.isatty():
             # Implement pagination (only if at least one chunk was printed)
-            if printed:
+            if printed and page_num != args.max_pages - 1:
                 print("----- Press Enter to continue or Ctrl-C to exit -----")
                 raw_input()
 
@@ -142,11 +215,17 @@ def fetch_json_pages(query_id, printed_chunks, args):
 def main():
     args = parse_args()
 
+    if args.quiet:
+        requests.packages.urllib3.disable_warnings()
+
     # Execute query over a websocket
     last_ws_chunk, printed_chunks = run_websocket_query(args)
     query_id = last_ws_chunk['QueryId']
 
     fetch_json_pages(query_id, printed_chunks, args)
+
+    if args.dedupe:
+        print_dedupe(args.linenumber, args.print_filenames, args.nocolor)
 
     say(args.quiet, "--\nFiles grepped: %d" % last_ws_chunk['FilesTotal'])
 
@@ -155,4 +234,5 @@ if __name__ == '__main__':
     try:
         main()
     except KeyboardInterrupt:
+        print("")
         sys.exit()


### PR DESCRIPTION
I have been using the web interface quite a lot, but am tired of clicking through pages and pages of duplicate results!

This version of the script supports de-duplicating the results so duplicate bodies are shown only once.

This version also supports /excluding/ by path, e.g. making it easy to exclude files with the word 'test' in their path.
